### PR TITLE
benchmark: Condtionalize AMD64 Time Stamp Counter

### DIFF
--- a/config_m4/rdtsc.m4
+++ b/config_m4/rdtsc.m4
@@ -6,7 +6,7 @@ AC_LINK_IFELSE([
 			int main(){
 			unsigned int hi, lo;
 			__asm__ volatile("rdtsc" : "=a" (lo), "=d" (hi));
-			printf("%lu, %u\n", hi, lo);
+			printf("%u, %u\n", hi, lo);
 			return 0;
 			}
 		]]

--- a/config_m4/rdtsc.m4
+++ b/config_m4/rdtsc.m4
@@ -1,0 +1,21 @@
+AC_MSG_CHECKING(whether RDTSC support is available)
+AC_LINK_IFELSE([
+	AC_LANG_SOURCE(
+		[[
+			#include <stdio.h>
+			int main(){
+			unsigned int hi, lo;
+			__asm__ volatile("rdtsc" : "=a" (lo), "=d" (hi));
+			printf("%lu, %u\n", hi, lo);
+			return 0;
+			}
+		]]
+  	)
+], [have_rdtsc=yes], [have_rdtsc=no])
+
+if test "$have_rdtsc" = "yes"; then
+	AC_DEFINE([HAVE_RDTSC], [], [Define if RDTSC support is detected.])
+	AC_MSG_RESULT(yes)
+else
+	AC_MSG_RESULT(no)
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,9 @@ m4_include([config_m4/versioning.m4])
 # Checking valgrind
 m4_include([config_m4/valgrind.m4])
 
+# Checking RDTSC
+m4_include([config_m4/rdtsc.m4])
+
 # Output files
 AC_CONFIG_FILES([
 	Makefile

--- a/test/benchmark.cc
+++ b/test/benchmark.cc
@@ -53,7 +53,7 @@ CDADA_MAP_CUSTOM_TYPE_DECL(test_u3552_t);
 CDADA_SET_CUSTOM_TYPE_DECL(test_u3552_t);
 CDADA_STACK_CUSTOM_TYPE_DECL(test_u3552_t);
 
-#ifdef __amd64__
+#ifdef HAVE_RDTSC
 
 #if 10
 
@@ -1085,6 +1085,12 @@ int main(int args, char** argv){
 	struct sched_param params;
 	params.sched_priority = sched_get_priority_max(SCHED_FIFO);
 	pthread_setschedparam(this_thread, SCHED_FIFO, &params);
+
+#ifndef HAVE_RDTSC
+	fprintf(stdout, "############################# ATTENTION #############################\n");
+	fprintf(stdout, "Warning! RDTSC support is not available. All time values will be zero\n");
+	fprintf(stdout, "############################# ATTENTION #############################\n\n");
+#endif
 
 	/**********************************************************************/
 	/* uint32_t                                                           */

--- a/test/benchmark.cc
+++ b/test/benchmark.cc
@@ -53,6 +53,8 @@ CDADA_MAP_CUSTOM_TYPE_DECL(test_u3552_t);
 CDADA_SET_CUSTOM_TYPE_DECL(test_u3552_t);
 CDADA_STACK_CUSTOM_TYPE_DECL(test_u3552_t);
 
+#ifdef __amd64__
+
 #if 10
 
 //Assembly to read rdtsc
@@ -72,6 +74,13 @@ static inline uint64_t RDTSC()
 #define RDTSC __rdtsc
 #endif
 
+#else
+
+#pragma message ( "Platform does not support Time Stamp Counter!" )
+#pragma message ( "All time values will be zero" )
+#define RDTSC() 0
+
+#endif
 
 
 uint32_t big_array[] = {


### PR DESCRIPTION
Use a Time Stamp Counter only on AMD64 based platforms. Other platforms
will have the ability to run the benchmark, but zeros will be reported
as time values. A warning is printed at compile time to notify the user
that Time Stamp Counters are not available for non-AMD64 based platforms.