### PR TITLE
str: add cdada_str_ncmp/cdada_str_ncmp_c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Legend:
 - [O] Other
 ```
 
+### v0.5.1 (5th September 2023)
+
+- [+] str: add string comparison functions `cdada_str_ncmp` and `cdada_str_ncmp_c`
+
 ### v0.5.0 (26th August 2023)
 
 - [+] map: add `cdada_map_get_pos()`

--- a/include/cdada/str.h
+++ b/include/cdada/str.h
@@ -245,6 +245,30 @@ int cdada_str_get_c(const cdada_str_t* str, const uint32_t pos, char* c);
 */
 int cdada_str_last_c(const cdada_str_t* str, char* c);
 
+//Comparison
+
+/**
+* Compares the two (cdada) strings s1 and s2. Locale is not taken into account.
+* It returns 0 if s1 and s2 are equal, a negative value if s1 is less than s2,
+* 1 if s1 is greater than s2.
+*
+* @param s1 String pointer
+* @param s2 String pointer
+* @param n  Compare at most n characters. Use 0 to behave as strcmp()
+*/
+int cdada_str_ncmp(const cdada_str_t* s1, const cdada_str_t* s2, uint32_t n);
+
+/**
+* Compares the two strings s1 (cdada) and s2 (C string). Locale is not taken
+* into account. It returns 0 if s1 and s2 are equal, a negative value if s1 is
+* less than s2, 1 if s1 is greater than s2.
+*
+* @param s1 cdada string pointer
+* @param s2 C string pointer
+* @param n  Compare at most n characters. Use 0 to behave as strcmp()
+*/
+int cdada_str_ncmp_c(const cdada_str_t* s1, const char* s2, uint32_t n);
+
 //Manipulation
 
 /**

--- a/src/str.cc
+++ b/src/str.cc
@@ -341,6 +341,33 @@ int cdada_str_last_c(const cdada_str_t* str, char* c){
 	return CDADA_SUCCESS;
 }
 
+//Comparison
+
+int cdada_str_ncmp(const cdada_str_t* s1_, const cdada_str_t* s2_, uint32_t n){
+	__cdada_str_int_t* s1 = (__cdada_str_int_t*)s1_;
+	__cdada_str_int_t* s2 = (__cdada_str_int_t*)s2_;
+
+	if(!s1 || s1->magic_num != CDADA_MAGIC)
+		return -1; //Whatever
+	if(!s2 || s2->magic_num != CDADA_MAGIC)
+		return -1; //Whatever
+	if(n == 0)
+		return strcmp(s1->str->c_str(), s2->str->c_str());
+	return strncmp(s1->str->c_str(), s2->str->c_str(), n);
+}
+
+int cdada_str_ncmp_c(const cdada_str_t* s1_, const char* s2, uint32_t n){
+	__cdada_str_int_t* s1 = (__cdada_str_int_t*)s1_;
+
+	if(!s1 || s1->magic_num != CDADA_MAGIC)
+		return -1; //Whatever
+	if(!s2)
+		return -1; //Whatever
+	if(n == 0)
+		return strcmp(s1->str->c_str(), s2);
+	return strncmp(s1->str->c_str(), s2, n);
+}
+
 //Manipulation
 
 int cdada_str_set(cdada_str_t* str, const char* substr){

--- a/test/str_test.c
+++ b/test/str_test.c
@@ -357,6 +357,70 @@ int test_manipulation(){
 	return 0;
 }
 
+int test_cmp(){
+
+	int rv;
+	//Don't use const char; strcmp impl. returns -1,0,1 otherwise
+	//(compile time optimization?)
+	char s1[] = "This is a test test";
+	char s2[] = "This is another test test";
+
+	cdada_str_t* c1 = cdada_str_create(s1);
+	TEST_ASSERT(c1 != NULL);
+	TEST_ASSERT(cdada_str_empty(c1) == false);
+	TEST_ASSERT(cdada_str_length(c1) == strlen(s1));
+
+	cdada_str_t* c2 = cdada_str_create(s2);
+	TEST_ASSERT(c2 != NULL);
+	TEST_ASSERT(cdada_str_empty(c2) == false);
+	TEST_ASSERT(cdada_str_length(c2) == strlen(s2));
+
+	//
+	//strcmp equivalent
+	//
+
+	//cdada
+	TEST_ASSERT(cdada_str_ncmp(c1, c2, 0) == strcmp(s1, s2));
+	TEST_ASSERT(cdada_str_ncmp(c2, c1, 0) == strcmp(s2, s1));
+	TEST_ASSERT(cdada_str_ncmp(c1, c1, 0) == strcmp(s1, s1));
+	TEST_ASSERT(cdada_str_ncmp(c2, c2, 0) == strcmp(s2, s2));
+	TEST_ASSERT(cdada_str_ncmp(c1, c1, 0) == 0);
+	TEST_ASSERT(cdada_str_ncmp(c2, c2, 0) == 0);
+
+	//cdada-C
+	TEST_ASSERT(cdada_str_ncmp_c(c1, s2, 0) == strcmp(s1, s2));
+	TEST_ASSERT(cdada_str_ncmp_c(c2, s1, 0) == strcmp(s2, s1));
+	TEST_ASSERT(cdada_str_ncmp_c(c1, s1, 0) == strcmp(s1, s1));
+	TEST_ASSERT(cdada_str_ncmp_c(c2, s2, 0) == strcmp(s2, s2));
+	TEST_ASSERT(cdada_str_ncmp_c(c1, s1, 0) == 0);
+	TEST_ASSERT(cdada_str_ncmp_c(c2, s2, 0) == 0);
+
+	//
+	//strncmp equivalent
+	//
+
+	//cdada
+	TEST_ASSERT(cdada_str_ncmp(c1, c2, 7) == strncmp(s1, s2, 7));
+	TEST_ASSERT(cdada_str_ncmp(c1, c2, 10) == strncmp(s1, s2, 10));
+	TEST_ASSERT(cdada_str_ncmp(c1, c2, 12) == strncmp(s1, s2, 12));
+	int overlen_avoid_compiler_warn = cdada_str_length(c1)*8;
+	TEST_ASSERT(cdada_str_ncmp(c1, c2, overlen_avoid_compiler_warn)
+			== strncmp(s1, s2, overlen_avoid_compiler_warn));
+
+	TEST_ASSERT(cdada_str_ncmp_c(c1, s2, 7) == strncmp(s1, s2, 7));
+	TEST_ASSERT(cdada_str_ncmp(c1, s2, 10) == strncmp(s1, s2, 10));
+	TEST_ASSERT(cdada_str_ncmp(c1, s2, 12) == strncmp(s1, s2, 12));
+	TEST_ASSERT(cdada_str_ncmp(c1, s2, overlen_avoid_compiler_warn)
+			== strncmp(s1, s2, overlen_avoid_compiler_warn));
+
+	rv = cdada_str_destroy(c1);
+	TEST_ASSERT(rv == CDADA_SUCCESS);
+	rv = cdada_str_destroy(c2);
+	TEST_ASSERT(rv == CDADA_SUCCESS);
+
+	return 0;
+}
+
 int main(int args, char** argv){
 
 	int rv;
@@ -371,6 +435,7 @@ int main(int args, char** argv){
 	rv = test_basics();
 	rv |= test_access();
 	rv |= test_manipulation();
+	rv |= test_cmp();
 
 	//Add your test here, and return a code appropriately...
 	return rv == 0? EXIT_SUCCESS : EXIT_FAILURE;


### PR DESCRIPTION
This commit adds support to compare (strcmp/strncmp) two cdada strings or a cdada string and a regular C string.

It also adds test coverage.