### PR TITLE
map: add prev_val to insert_replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Legend:
 - [O] Other
 ```
 
+### v0.6.0 (13th February 2024)
+
+- [+] !! BREAKING CHANGE !! Add `prev_val` to `cdada_map_insert_replace()` API call to make it more useful
+
 ### v0.5.2 (7th November 2023)
 
 - [B] map: don't penalize failed insert/erase/find operations (branch prediction)

--- a/examples/custom-gen/cdada.cc
+++ b/examples/custom-gen/cdada.cc
@@ -215,11 +215,12 @@ uint32_t __cdada_map_autogen_size_bar_t (const void* m){
 }
 int __cdada_map_autogen_insert_bar_t (void* m, const void* key,
 						void* val,
-						const bool replace){
+						const bool replace,
+						void** prev_val){
 	__cdada_map_int_t* s = (__cdada_map_int_t*)m;
 	std::map<bar_t, void*>* p =
 			(std::map<bar_t, void*>*)s->map.custom;
-	return cdada_map_insert_u<bar_t> (s, p, key, val, replace);
+	return cdada_map_insert_u<bar_t> (s, p, key, val, replace, prev_val);
 }
 int __cdada_map_autogen_erase_bar_t (void* m, const void* key){
 	__cdada_map_int_t* s = (__cdada_map_int_t*)m;

--- a/include/cdada/__map_internal.h
+++ b/include/cdada/__map_internal.h
@@ -60,7 +60,8 @@ typedef struct __cdada_map_ops{
 	bool (*empty)(const cdada_map_t* map);
 	uint32_t (*size)(const cdada_map_t* map);
 	int (*insert)(cdada_map_t* map, const void* key, void* val,
-							const bool replace);
+							const bool replace,
+							void** prev_val);
 	int (*erase)(cdada_map_t* map, const void* key);
 	int (*find)(const cdada_map_t* map, const void* key, void** val);
 	int (*get_pos)(const cdada_map_t* map, const uint32_t pos,
@@ -100,7 +101,8 @@ template<typename T>
 int cdada_map_insert_u(__cdada_map_int_t* m, std::map<T, void*>* m_u,
 							const void* key,
 							void* val,
-							const bool replace){
+							const bool replace,
+							void** prev_val){
 	typename std::map<T, void*>::iterator it;
 
 	if(m->key_len == m->user_key_len){
@@ -111,6 +113,10 @@ int cdada_map_insert_u(__cdada_map_int_t* m, std::map<T, void*>* m_u,
 		it = m_u->find(*aux);
 		if(!replace && it != m_u->end())
 			return CDADA_E_EXISTS;
+
+		if(replace && prev_val)
+			*prev_val = it->second;
+
 		(*m_u)[*aux] = val;
 
 		return CDADA_SUCCESS;
@@ -125,6 +131,9 @@ int cdada_map_insert_u(__cdada_map_int_t* m, std::map<T, void*>* m_u,
 	it = m_u->find(aux);
 	if(!replace && it != m_u->end())
 		return CDADA_E_EXISTS;
+
+	if(replace && prev_val)
+		*prev_val = it->second;
 
 	(*m_u)[aux] = val;
 

--- a/include/cdada/map.h
+++ b/include/cdada/map.h
@@ -179,6 +179,8 @@ int cdada_map_insert(cdada_map_t* map, const void* key, void* val);
 * @param map Map pointer
 * @param key Key. The key type _must_ have all bytes initialized
 * @param val Pointer to the value
+* @param prev_val If not NULL, when replacing a value the previous value will be
+*                 set here, regardless if the operation is successful or not
 *
 * @returns Return codes:
 *          CDADA_SUCCESS: element is inserted
@@ -186,7 +188,8 @@ int cdada_map_insert(cdada_map_t* map, const void* key, void* val);
 *          CDADA_E_UNKNOWN: corrupted map or internal error (bug)
 *          CDADA_E_INVALID: map is NULL or corrupted
 */
-int cdada_map_insert_replace(cdada_map_t* map, const void* key, void* val);
+int cdada_map_insert_replace(cdada_map_t* map, const void* key, void* val,
+							void** prev_val);
 
 /**
 * Erase an element in the map

--- a/include/cdada/map_custom_cc.h
+++ b/include/cdada/map_custom_cc.h
@@ -108,11 +108,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define __CDADA_MAP_CUSTOM_INSERT_F(TYPE) \
 	int __cdada_map_autogen_insert_##TYPE (void* m, const void* key, \
 							void* val, \
-							const bool replace){ \
+							const bool replace, \
+							void** prev_val){ \
 		__cdada_map_int_t* s = (__cdada_map_int_t*)m; \
 		__CDADA_STD_MAP_TYPE(TYPE)* p = \
 				(__CDADA_STD_MAP_TYPE(TYPE)*)s->map.custom; \
-		return cdada_map_insert_u< TYPE > (s, p, key, val, replace);\
+		return cdada_map_insert_u< TYPE > (s, p, key, val, replace, \
+								prev_val);\
 	}
 /**
 * @internal Custom type erase f

--- a/src/map.cc
+++ b/src/map.cc
@@ -266,7 +266,8 @@ uint32_t cdada_map_size(const cdada_map_t* map){
 }
 
 int _cdada_map_insert(cdada_map_t* map, const void* key, void* val,
-						const bool replace){
+						const bool replace,
+						void** prev_val){
 
 	__cdada_map_int_t* m = (__cdada_map_int_t*)map;
 
@@ -285,58 +286,68 @@ int _cdada_map_insert(cdada_map_t* map, const void* key, void* val,
 								m->map.u8,
 								key,
 								val,
-								replace);
+								replace,
+								prev_val);
 			case 2:
 				return cdada_map_insert_u<uint16_t>(m,
 								m->map.u16,
 								key,
 								val,
-								replace);
+								replace,
+								prev_val);
 			case 4:
 				return cdada_map_insert_u<uint32_t>(m,
 								m->map.u32,
 								key,
 								val,
-								replace);
+								replace,
+								prev_val);
 			case 8:
 				return cdada_map_insert_u<uint64_t>(m,
 								m->map.u64,
 								key,
 								val,
-								replace);
+								replace,
+								prev_val);
 			case 16:
 				return cdada_map_insert_u<cdada_u128_t>(m,
 								m->map.u128,
 								key,
 								val,
-								replace);
+								replace,
+								prev_val);
 			case 32:
 				return cdada_map_insert_u<cdada_u256_t>(m,
 								m->map.u256,
 								key,
 								val,
-								replace);
+								replace,
+								prev_val);
 			case 64:
 				return cdada_map_insert_u<cdada_u512_t>(m,
 								m->map.u512,
 								key,
 								val,
-								replace);
+								replace,
+								prev_val);
 			case 128:
 				return cdada_map_insert_u<cdada_u1024_t>(m,
 								m->map.u1024,
 								key,
 								val,
-								replace);
+								replace,
+								prev_val);
 			case 256:
 				return cdada_map_insert_u<cdada_u2048_t>(m,
 								m->map.u2048,
 								key,
 								val,
-								replace);
+								replace,
+								prev_val);
 			case 0:
 				CDADA_ASSERT(m->ops);
-				return (*m->ops->insert)(m, key, val, replace);
+				return (*m->ops->insert)(m, key, val, replace,
+								prev_val);
 			default:
 				break;
 		}
@@ -349,11 +360,12 @@ int _cdada_map_insert(cdada_map_t* map, const void* key, void* val,
 }
 
 int cdada_map_insert(cdada_map_t* map, const void* key, void* val){
-	return _cdada_map_insert(map, key, val, false);
+	return _cdada_map_insert(map, key, val, false, NULL);
 }
 
-int cdada_map_insert_replace(cdada_map_t* map, const void* key, void* val){
-	return _cdada_map_insert(map, key, val, true);
+int cdada_map_insert_replace(cdada_map_t* map, const void* key, void* val,
+							void** prev_val){
+	return _cdada_map_insert(map, key, val, true, prev_val);
 }
 
 int cdada_map_erase(cdada_map_t* map, const void* key){

--- a/test/map_test.c
+++ b/test/map_test.c
@@ -99,7 +99,7 @@ int test_u8_insert_removal(){
 
 	// -- Replace
 	key = 0;
-	rv = cdada_map_insert_replace(map, &key, &values[1]);
+	rv = cdada_map_insert_replace(map, &key, &values[1], NULL);
 	TEST_ASSERT(rv == CDADA_SUCCESS);
 
 	rv = cdada_map_find(map, &key, &tmp);
@@ -108,8 +108,9 @@ int test_u8_insert_removal(){
 	TEST_ASSERT(tmp == &values[1]);
 
 	key = 0;
-	rv = cdada_map_insert_replace(map, &key, &values[0]);
+	rv = cdada_map_insert_replace(map, &key, &values[0], &tmp);
 	TEST_ASSERT(rv == CDADA_SUCCESS);
+	TEST_ASSERT(tmp == &values[1]);
 	// -- End replace
 
 	rv = cdada_map_find(map, &key, &tmp);
@@ -693,7 +694,7 @@ int _test_u552_insert_removal_traverse(){
 
 	// -- Replace
 	key.mid = 0;
-	rv = cdada_map_insert_replace(map, &key, &values[1]);
+	rv = cdada_map_insert_replace(map, &key, &values[1], NULL);
 	TEST_ASSERT(rv == CDADA_SUCCESS);
 
 	rv = cdada_map_find(map, &key, &tmp);
@@ -702,8 +703,9 @@ int _test_u552_insert_removal_traverse(){
 	TEST_ASSERT(tmp == &values[1]);
 
 	key.mid = 0;
-	rv = cdada_map_insert_replace(map, &key, &values[0]);
+	rv = cdada_map_insert_replace(map, &key, &values[0], &tmp);
 	TEST_ASSERT(rv == CDADA_SUCCESS);
+	TEST_ASSERT(tmp == &values[1]);
 	// -- End replace
 
 	rv = cdada_map_find(map, &key, &tmp);
@@ -875,7 +877,7 @@ int test_u3552_insert_removal_traverse_custom(){
 
 	// -- Replace
 	key.mid = 0;
-	rv = cdada_map_insert_replace(map, &key, &values[1]);
+	rv = cdada_map_insert_replace(map, &key, &values[1], NULL);
 	TEST_ASSERT(rv == CDADA_SUCCESS);
 
 	rv = cdada_map_find(map, &key, &tmp);
@@ -884,8 +886,9 @@ int test_u3552_insert_removal_traverse_custom(){
 	TEST_ASSERT(tmp == &values[1]);
 
 	key.mid = 0;
-	rv = cdada_map_insert_replace(map, &key, &values[0]);
+	rv = cdada_map_insert_replace(map, &key, &values[0], &tmp);
 	TEST_ASSERT(rv == CDADA_SUCCESS);
+	TEST_ASSERT(tmp == &values[1]);
 	// -- End replace
 
 	rv = cdada_map_find(map, &key, &tmp);

--- a/tools/cdada-gen
+++ b/tools/cdada-gen
@@ -193,11 +193,12 @@ uint32_t __cdada_map_autogen_size_TT_TYPE_TT (const void* m){
 }
 int __cdada_map_autogen_insert_TT_TYPE_TT (void* m, const void* key,
 						void* val,
-						const bool replace){
+						const bool replace,
+						void** prev_val){
 	__cdada_map_int_t* s = (__cdada_map_int_t*)m;
 	std::map<TT_TYPE_TT, void*>* p =
 			(std::map<TT_TYPE_TT, void*>*)s->map.custom;
-	return cdada_map_insert_u<TT_TYPE_TT> (s, p, key, val, replace);
+	return cdada_map_insert_u<TT_TYPE_TT> (s, p, key, val, replace, prev_val);
 }
 int __cdada_map_autogen_erase_TT_TYPE_TT (void* m, const void* key){
 	__cdada_map_int_t* s = (__cdada_map_int_t*)m;


### PR DESCRIPTION
In order to make the API cdada_map_insert_replace more useful, add the optional `prev_val`. If not NULL, the previous value will be filled in (regardless if the API call is successful or not).

Mind this is a BREAKING CHANGE for this API.

Fixes #15