### PR TITLE
str: use correct cdada comparison function for a regular C string

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   gcc_ubuntu_18_04:
     strategy:
@@ -26,7 +29,7 @@ jobs:
           apt-get update && apt-get install -y git
 
       - name: "Checkout libcdada"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: libcdada
 
@@ -53,7 +56,7 @@ jobs:
       CXX: g++-${{ matrix.version }}
     steps:
       - name: "Checkout libcdada"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: libcdada
 
@@ -82,7 +85,7 @@ jobs:
       CXXFLAGS: -gdwarf-4
     steps:
       - name: "Checkout libcdada"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: libcdada
 

--- a/test/str_test.c
+++ b/test/str_test.c
@@ -408,9 +408,9 @@ int test_cmp(){
 			== strncmp(s1, s2, overlen_avoid_compiler_warn));
 
 	TEST_ASSERT(cdada_str_ncmp_c(c1, s2, 7) == strncmp(s1, s2, 7));
-	TEST_ASSERT(cdada_str_ncmp(c1, s2, 10) == strncmp(s1, s2, 10));
-	TEST_ASSERT(cdada_str_ncmp(c1, s2, 12) == strncmp(s1, s2, 12));
-	TEST_ASSERT(cdada_str_ncmp(c1, s2, overlen_avoid_compiler_warn)
+	TEST_ASSERT(cdada_str_ncmp_c(c1, s2, 10) == strncmp(s1, s2, 10));
+	TEST_ASSERT(cdada_str_ncmp_c(c1, s2, 12) == strncmp(s1, s2, 12));
+	TEST_ASSERT(cdada_str_ncmp_c(c1, s2, overlen_avoid_compiler_warn)
 			== strncmp(s1, s2, overlen_avoid_compiler_warn));
 
 	rv = cdada_str_destroy(c1);


### PR DESCRIPTION
The `cdada_str_ncmp_c` function must be used for comparison with regular C string, otherwise `str_test` aborts.

Fixes: be47ae8cb148 ("str: add cdada_str_ncmp/cdada_str_ncmp_c")