### PR TITLE
map: set ptr_not_null to a valid pointer

### DIFF
--- a/test/map_test.c
+++ b/test/map_test.c
@@ -552,7 +552,8 @@ int test_basics(){
 
 	int rv;
 
-	void* ptr_not_null = (void*)0x123;
+	int i = 0x123;
+	void* ptr_not_null = (void*)&i;
 
 	//Create
 	map = cdada_map_create(int);


### PR DESCRIPTION
`ptr_not_null` should contain a valid pointer, otherwise the `map_test` can segfault. Common patter used in `__map_internal.h` is

```c
  T* aux;
  aux = (T*)key;
  it = m_u->find(*aux);
```

The `key` is set to `(void*)0x123` in multiple `test_basics` test cases. It is cast to `(int*)` and dereferenced in `find` method call. This is the place where `map_test` can segfault as it cannot access memory at address `0x123`.

This issue is fixed by using a real accessible pointer to an integer with value `0x123`.

---

Here is the gdb backtrace from segfault:

```
Program received signal SIGSEGV, Segmentation fault.
0x00007f408a804dba in std::_Rb_tree<unsigned int, std::pair<unsigned int const, void*>, std::_Select1st<std::pair<unsigned int const, void*> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, void*> > >::_M_end (
    this=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_tree.h:748
748           { return &this->_M_impl._M_header; }
(gdb) bt
#0  0x00007f408a804dba in std::_Rb_tree<unsigned int, std::pair<unsigned int const, void*>, std::_Select1st<std::pair<unsigned int const, void*> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, void*> > >::_M_end
    (this=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_tree.h:748
#1  std::_Rb_tree<unsigned int, std::pair<unsigned int const, void*>, std::_Select1st<std::pair<unsigned int const, void*> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, void*> > >::find (__k=<optimized out>,
    this=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_tree.h:2528
#2  std::map<unsigned int, void*, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, void*> > >::find (this=0x55ef5ec642e0, __x=<error reading variable: Cannot access memory at address 0x123>)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_map.h:1219
#3  cdada_map_find_u<unsigned int> (m=0x55ef5ec642b0, m_u=0x55ef5ec642e0, key=0x123, val=0x0)
    at ../include/cdada/__map_internal.h:186
#4  cdada_map_find (map=0x55ef5ec642b0, key=0x123, val=0x0) at map.cc:456
#5  0x000055ef5ddf3c91 in test_basics ()
#6  0x000055ef5ddf24ff in main ()
```
I am actually surprised that it does not segfault every time. The issue is related to https://bugs.gentoo.org/936651.